### PR TITLE
Clarify inheritance behaviour of route params in .params (#1515)

### DIFF
--- a/_includes/api/en/4x/app-param.md
+++ b/_includes/api/en/4x/app-param.md
@@ -22,7 +22,7 @@ app.param('user', function (req, res, next, id) {
 })
 ```
 
-Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `app` will be triggered only by route parameters defined on `app` routes.
+Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers, nor are they triggered for route parameters inherited from parent routers. Hence, param callbacks defined on `app` will be triggered only by route parameters defined on `app` routes.
 
 All param callbacks will be called before any handler of any route in which the param occurs, and they will each be called only once in a request-response cycle, even if the parameter is matched in multiple routes, as shown in the following examples.
 

--- a/_includes/api/en/4x/router-param.md
+++ b/_includes/api/en/4x/router-param.md
@@ -32,7 +32,7 @@ router.param('user', function (req, res, next, id) {
 })
 ```
 
-Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `router` will be triggered only by route parameters defined on `router` routes.
+Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers, nor are they triggered for route parameters inherited from parent routers. Hence, param callbacks defined on `router` will be triggered only by route parameters defined on `router` routes.
 
 A param callback will be called only once in a request-response cycle, even if the parameter is matched in multiple routes, as shown in the following examples.
 

--- a/_includes/api/en/5x/app-param.md
+++ b/_includes/api/en/5x/app-param.md
@@ -22,7 +22,7 @@ app.param('user', (req, res, next, id) => {
 })
 ```
 
-Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `app` will be triggered only by route parameters defined on `app` routes.
+Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers, nor are they triggered for route parameters inherited from parent routers. Hence, param callbacks defined on `app` will be triggered only by route parameters defined on `app` routes.
 
 All param callbacks will be called before any handler of any route in which the param occurs, and they will each be called only once in a request-response cycle, even if the parameter is matched in multiple routes, as shown in the following examples.
 

--- a/_includes/api/en/5x/router-param.md
+++ b/_includes/api/en/5x/router-param.md
@@ -32,7 +32,7 @@ router.param('user', (req, res, next, id) => {
 })
 ```
 
-Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `router` will be triggered only by route parameters defined on `router` routes.
+Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers, nor are they triggered for route parameters inherited from parent routers. Hence, param callbacks defined on `router` will be triggered only by route parameters defined on `router` routes.
 
 A param callback will be called only once in a request-response cycle, even if the parameter is matched in multiple routes, as shown in the following examples.
 


### PR DESCRIPTION
Current documentation specifies router param callbacks are not inherited by mounted apps or routers, but does not also specify they do not inherit from parent routers either.